### PR TITLE
No need for full link

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,5 @@
 # Jira
-[TIX-NUM](https://clearsummit.atlassian.net/browse/TIX-NUM)
+[TIX-NUM]
 
 # Description
 Brief description of the changes introduced


### PR DESCRIPTION
# Description
It is not necessary to have the full link in the template. The github JIRA integration will generate this for us.

If it is not being generated we should troubleshoot why it is not getting generated

Including a full link creates extra work and often results in a broken link because only the displayed text is changed instead of changing it in two places

Including the short link requires the change in only one place



